### PR TITLE
fix: add check and trigger error if autoload is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,5 @@ Prefix the change with one of these keywords:
 - _Security_: in case of vulnerabilities.
 
 ## [Unreleased]
+
+- _Fixed_: Check for autoload.php before requiring it.

--- a/plugin.php
+++ b/plugin.php
@@ -22,8 +22,12 @@ define( 'MULTI_BLOCK_STARTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'MULTI_BLOCK_STARTER_URL', plugin_dir_url( __FILE__ ) );
 
 // Include Composer's autoload file.
-require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
-
+if ( file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
+	require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+} else {
+	wp_trigger_error( ' Multi Block Starter Plugin: Composer autoload file not found. Please run `composer install` to install the dependencies.', E_USER_ERROR );
+	return;
+}
 // Instantiate the classes.
 $multi_block_starter_classes = array(
 	\Multi_Block_Starter\Enqueues::class,


### PR DESCRIPTION
## Description

If the plugin is activated before `composer install` is run, it will fire an error. This PR adds a check and triggers a warning to the user.

## Related Issue

Related #18 

## Testing Instructions

1. Remove the `vendor` dir on main branch and activate the plugin.
2. Confirm there is a fatal error
3. Switch to this branch and try to activate
4. Confirm that WordPress still loads but a warning is fired telling the user to run `composer install`
## Checklist

-   [x] Have you added a note to the changelog?
-   [x] Have you ensured the code passes all tests using the included plugin-check?
-   [x] Have you checked for code style and linting errors?
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 